### PR TITLE
Fix security vulnerabilities via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,30 @@
 			"dev": true
 		},
 		"accepts": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-			"integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+			"integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
 			"dev": true,
 			"requires": {
-				"mime-types": "~2.1.18",
-				"negotiator": "0.6.1"
+				"mime-types": "~2.1.24",
+				"negotiator": "0.6.2"
+			},
+			"dependencies": {
+				"mime-db": {
+					"version": "1.40.0",
+					"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+					"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+					"dev": true
+				},
+				"mime-types": {
+					"version": "2.1.24",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+					"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+					"dev": true,
+					"requires": {
+						"mime-db": "1.40.0"
+					}
+				}
 			}
 		},
 		"acorn": {
@@ -352,29 +369,21 @@
 			"dev": true
 		},
 		"async-done": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.1.tgz",
-			"integrity": "sha512-R1BaUeJ4PMoLNJuk+0tLJgjmEqVsdN118+Z8O+alhnQDQgy0kmD5Mqi0DNEmMx2LM0Ed5yekKu+ZXYvIHceicg==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/async-done/-/async-done-1.3.2.tgz",
+			"integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.2",
-				"process-nextick-args": "^1.0.7",
+				"process-nextick-args": "^2.0.0",
 				"stream-exhaust": "^1.0.1"
-			},
-			"dependencies": {
-				"process-nextick-args": {
-					"version": "1.0.7",
-					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-					"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-					"dev": true
-				}
 			}
 		},
 		"async-each": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-			"integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+			"integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
 			"dev": true
 		},
 		"async-each-series": {
@@ -390,9 +399,9 @@
 			"dev": true
 		},
 		"async-limiter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+			"integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
 			"dev": true
 		},
 		"async-settle": {
@@ -443,13 +452,21 @@
 			"dev": true
 		},
 		"axios": {
-			"version": "0.17.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-			"integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+			"integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
 			"dev": true,
 			"requires": {
-				"follow-redirects": "^1.2.5",
-				"is-buffer": "^1.1.5"
+				"follow-redirects": "1.5.10",
+				"is-buffer": "^2.0.2"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+					"integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+					"dev": true
+				}
 			}
 		},
 		"bach": {
@@ -579,9 +596,9 @@
 			}
 		},
 		"binary-extensions": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-			"integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+			"version": "1.13.1",
+			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
 		"blob": {
@@ -645,13 +662,13 @@
 			}
 		},
 		"browser-sync": {
-			"version": "2.26.3",
-			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.3.tgz",
-			"integrity": "sha512-VLzpjCA4uXqfzkwqWtMM6hvPm2PNHp2RcmzBXcbi6C9WpkUhhFb8SVAr4CFrCsFxDg+oY6HalOjn8F+egyvhag==",
+			"version": "2.26.7",
+			"resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.7.tgz",
+			"integrity": "sha512-lY3emme0OyvA2ujEMpRmyRy9LY6gHLuTr2/ABxhIm3lADOiRXzP4dgekvnDrQqZ/Ec2Fz19lEjm6kglSG5766w==",
 			"dev": true,
 			"requires": {
-				"browser-sync-client": "^2.26.2",
-				"browser-sync-ui": "^2.26.2",
+				"browser-sync-client": "^2.26.6",
+				"browser-sync-ui": "^2.26.4",
 				"bs-recipes": "1.3.4",
 				"bs-snippet-injector": "^2.0.1",
 				"chokidar": "^2.0.4",
@@ -665,8 +682,8 @@
 				"fs-extra": "3.0.1",
 				"http-proxy": "1.15.2",
 				"immutable": "^3",
-				"localtunnel": "1.9.1",
-				"micromatch": "2.3.11",
+				"localtunnel": "1.9.2",
+				"micromatch": "^3.1.10",
 				"opn": "5.3.0",
 				"portscanner": "2.1.1",
 				"qs": "6.2.3",
@@ -683,9 +700,9 @@
 			}
 		},
 		"browser-sync-client": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.2.tgz",
-			"integrity": "sha512-FEuVJD41fI24HJ30XOT2RyF5WcnEtdJhhTqeyDlnMk/8Ox9MZw109rvk9pdfRWye4soZLe+xcAo9tHSMxvgAdw==",
+			"version": "2.26.6",
+			"resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.6.tgz",
+			"integrity": "sha512-mGrkZdNzttKdf/16I+y+2dTQxoMCIpKbVIMJ/uP8ZpnKu9f9qa/2CYVtLtbjZG8nsM14EwiCrjuFTGBEnT3Gjw==",
 			"dev": true,
 			"requires": {
 				"etag": "1.8.1",
@@ -695,9 +712,9 @@
 			}
 		},
 		"browser-sync-ui": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.2.tgz",
-			"integrity": "sha512-LF7GMWo8ELOE0eAlxuRCfnGQT1ZxKP9flCfGgZdXFc6BwmoqaJHlYe7MmVvykKkXjolRXTz8ztXAKGVqNwJ3EQ==",
+			"version": "2.26.4",
+			"resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.4.tgz",
+			"integrity": "sha512-u20P3EsZoM8Pt+puoi3BU3KlbQAH1lAcV+/O4saF26qokrBqIDotmGonfWwoRbUmdxZkM9MBmA0K39ZTG1h4sA==",
 			"dev": true,
 			"requires": {
 				"async-each-series": "0.1.1",
@@ -750,9 +767,9 @@
 			"dev": true
 		},
 		"bytes": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-			"integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+			"integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
 			"dev": true
 		},
 		"cache-base": {
@@ -858,24 +875,31 @@
 			}
 		},
 		"chokidar": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
-			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
+			"version": "2.1.8",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+			"integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
 			"dev": true,
 			"requires": {
 				"anymatch": "^2.0.0",
-				"async-each": "^1.0.0",
-				"braces": "^2.3.0",
-				"fsevents": "^1.2.2",
+				"async-each": "^1.0.1",
+				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
 				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.1",
+				"inherits": "^2.0.3",
 				"is-binary-path": "^1.0.0",
 				"is-glob": "^4.0.0",
-				"lodash.debounce": "^4.0.8",
-				"normalize-path": "^2.1.1",
+				"normalize-path": "^3.0.0",
 				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0",
-				"upath": "^1.0.5"
+				"readdirp": "^2.2.1",
+				"upath": "^1.1.1"
+			},
+			"dependencies": {
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				}
 			}
 		},
 		"clap": {
@@ -1083,9 +1107,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.19.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-			"integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+			"version": "2.20.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
 			"dev": true
 		},
 		"component-bind": {
@@ -1165,9 +1189,9 @@
 			}
 		},
 		"connect-history-api-fallback": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
-			"integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo=",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+			"integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
 			"dev": true
 		},
 		"console-browserify": {
@@ -1398,12 +1422,13 @@
 			"optional": true
 		},
 		"d": {
-			"version": "1.0.0",
-			"resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
-			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+			"integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
 			"dev": true,
 			"requires": {
-				"es5-ext": "^0.10.9"
+				"es5-ext": "^0.10.50",
+				"type": "^1.0.1"
 			}
 		},
 		"dashdash": {
@@ -1670,9 +1695,9 @@
 			}
 		},
 		"duplexify": {
-			"version": "3.6.1",
-			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
-			"integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+			"integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
 			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.0.0",
@@ -1774,9 +1799,9 @@
 			}
 		},
 		"engine.io-client": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.1.tgz",
-			"integrity": "sha512-q66JBFuQcy7CSlfAz9L3jH+v7DTT3i6ZEadYcVj2pOs8/0uJHLxKX3WBkGTvULJMdz0tUCyJag0aKT/dpXL9BQ==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.3.2.tgz",
+			"integrity": "sha512-y0CPINnhMvPuwtqXfsGuWE8BB66+B6wTtCofQDRecMQPYX3MYUZXFNKDhdrSe3EVjgOu4V3rxdeqN/Tr91IgbQ==",
 			"dev": true,
 			"requires": {
 				"component-emitter": "1.2.1",
@@ -1845,14 +1870,14 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.46",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-			"integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
+			"version": "0.10.51",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
+			"integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
 			"dev": true,
 			"requires": {
 				"es6-iterator": "~2.0.3",
 				"es6-symbol": "~3.1.1",
-				"next-tick": "1"
+				"next-tick": "^1.0.0"
 			}
 		},
 		"es6-iterator": {
@@ -1884,14 +1909,14 @@
 			}
 		},
 		"es6-weak-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
 			"dev": true,
 			"requires": {
 				"d": "1",
-				"es5-ext": "^0.10.14",
-				"es6-iterator": "^2.0.1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
 				"es6-symbol": "^3.1.1"
 			}
 		},
@@ -1977,63 +2002,6 @@
 					"dev": true,
 					"requires": {
 						"is-extendable": "^0.1.0"
-					}
-				}
-			}
-		},
-		"expand-range": {
-			"version": "1.8.2",
-			"resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
-			"requires": {
-				"fill-range": "^2.1.0"
-			},
-			"dependencies": {
-				"fill-range": {
-					"version": "2.2.4",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-					"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-					"dev": true,
-					"requires": {
-						"is-number": "^2.1.0",
-						"isobject": "^2.0.0",
-						"randomatic": "^3.0.0",
-						"repeat-element": "^1.1.2",
-						"repeat-string": "^1.5.2"
-					}
-				},
-				"is-number": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-					"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-					"dev": true,
-					"requires": {
-						"kind-of": "^3.0.2"
-					}
-				},
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
-				},
-				"isobject": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true,
-					"requires": {
-						"isarray": "1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
 					}
 				}
 			}
@@ -2210,12 +2178,6 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"filename-regex": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
-		},
 		"fill-range": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -2276,26 +2238,17 @@
 			}
 		},
 		"findup-sync": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
-			"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+			"integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
 			"dev": true,
 			"requires": {
 				"detect-file": "^1.0.0",
-				"is-glob": "^3.1.0",
+				"is-glob": "^4.0.0",
 				"micromatch": "^3.0.4",
 				"resolve-dir": "^1.0.1"
 			},
 			"dependencies": {
-				"is-glob": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^2.1.0"
-					}
-				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -2320,9 +2273,9 @@
 			}
 		},
 		"fined": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/fined/-/fined-1.1.0.tgz",
-			"integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fined/-/fined-1.2.0.tgz",
+			"integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
 			"dev": true,
 			"requires": {
 				"expand-tilde": "^2.0.2",
@@ -2333,9 +2286,9 @@
 			}
 		},
 		"flagged-respawn": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.0.tgz",
-			"integrity": "sha1-Tnmumy6zi/hrO7Vr8+ClaqX8q9c=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
+			"integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
 			"dev": true
 		},
 		"flatten": {
@@ -2345,13 +2298,13 @@
 			"dev": true
 		},
 		"flush-write-stream": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
-			"integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
+			"integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.4"
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.3.6"
 			}
 		},
 		"follow-redirects": {
@@ -2368,15 +2321,6 @@
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
 			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
 			"dev": true
-		},
-		"for-own": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
-			"requires": {
-				"for-in": "^1.0.1"
-			}
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -2438,14 +2382,14 @@
 			"dev": true
 		},
 		"fsevents": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+			"version": "1.2.9",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "^2.12.1",
+				"node-pre-gyp": "^0.12.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2467,7 +2411,7 @@
 					"optional": true
 				},
 				"are-we-there-yet": {
-					"version": "1.1.4",
+					"version": "1.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2493,7 +2437,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2523,16 +2467,16 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "2.6.9",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"deep-extend": {
-					"version": "0.5.1",
+					"version": "0.6.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2581,7 +2525,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.2",
+					"version": "7.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2601,12 +2545,12 @@
 					"optional": true
 				},
 				"iconv-lite": {
-					"version": "0.4.21",
+					"version": "0.4.24",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": ">= 2.1.2 < 3"
 					}
 				},
 				"ignore-walk": {
@@ -2671,17 +2615,17 @@
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.2.4",
+					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
 					}
 				},
 				"minizlib": {
-					"version": "1.1.0",
+					"version": "1.2.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2699,35 +2643,42 @@
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
+					"version": "2.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
+				"nan": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+					"dev": true,
+					"optional": true
+				},
 				"needle": {
-					"version": "2.2.0",
+					"version": "2.3.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
+						"debug": "^4.1.0",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
 				},
 				"node-pre-gyp": {
-					"version": "0.10.0",
+					"version": "0.12.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
 						"detect-libc": "^1.0.2",
 						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
+						"needle": "^2.2.1",
 						"nopt": "^4.0.1",
 						"npm-packlist": "^1.1.6",
 						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
+						"rc": "^1.2.7",
 						"rimraf": "^2.6.1",
 						"semver": "^5.3.0",
 						"tar": "^4"
@@ -2744,13 +2695,13 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.3",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.1.10",
+					"version": "1.4.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2827,12 +2778,12 @@
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.7",
+					"version": "1.2.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
+						"deep-extend": "^0.6.0",
 						"ini": "~1.3.0",
 						"minimist": "^1.2.0",
 						"strip-json-comments": "~2.0.1"
@@ -2862,16 +2813,16 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.2",
+					"version": "2.6.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "^7.1.3"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.1.1",
+					"version": "5.1.2",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2889,7 +2840,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.5.0",
+					"version": "5.7.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2942,17 +2893,17 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.1",
+					"version": "4.4.8",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
+						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
+						"minipass": "^2.3.4",
+						"minizlib": "^1.1.1",
 						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
+						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.2"
 					}
 				},
@@ -2963,12 +2914,12 @@
 					"optional": true
 				},
 				"wide-align": {
-					"version": "1.1.2",
+					"version": "1.1.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "^1.0.2 || 2"
 					}
 				},
 				"wrappy": {
@@ -2978,7 +2929,7 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.2",
+					"version": "3.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2986,9 +2937,9 @@
 			}
 		},
 		"fstream": {
-			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+			"integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
 			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.2",
@@ -3067,42 +3018,6 @@
 				"minimatch": "^3.0.4",
 				"once": "^1.3.0",
 				"path-is-absolute": "^1.0.0"
-			}
-		},
-		"glob-base": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
-			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"dependencies": {
-				"glob-parent": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-					"dev": true,
-					"requires": {
-						"is-glob": "^2.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
 			}
 		},
 		"glob-parent": {
@@ -3222,21 +3137,21 @@
 			"dev": true
 		},
 		"gulp": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.0.tgz",
-			"integrity": "sha1-lXZsYB2t5Kd+0+eyttwDiBtZY2Y=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/gulp/-/gulp-4.0.2.tgz",
+			"integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
 			"dev": true,
 			"requires": {
-				"glob-watcher": "^5.0.0",
-				"gulp-cli": "^2.0.0",
-				"undertaker": "^1.0.0",
+				"glob-watcher": "^5.0.3",
+				"gulp-cli": "^2.2.0",
+				"undertaker": "^1.2.1",
 				"vinyl-fs": "^3.0.0"
 			},
 			"dependencies": {
 				"gulp-cli": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.0.1.tgz",
-					"integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/gulp-cli/-/gulp-cli-2.2.0.tgz",
+					"integrity": "sha512-rGs3bVYHdyJpLqR0TUBnlcZ1O5O++Zs4bA0ajm+zr3WFCfiSLjGwoCBqFs18wzN+ZxahT9DkOK5nDf26iDsWjA==",
 					"dev": true,
 					"requires": {
 						"ansi-colors": "^1.0.1",
@@ -3249,7 +3164,7 @@
 						"gulplog": "^1.0.0",
 						"interpret": "^1.1.0",
 						"isobject": "^3.0.1",
-						"liftoff": "^2.5.0",
+						"liftoff": "^3.1.0",
 						"matchdep": "^2.0.0",
 						"mute-stdout": "^1.0.0",
 						"pretty-hrtime": "^1.0.0",
@@ -3604,9 +3519,9 @@
 					"dev": true
 				},
 				"js-yaml": {
-					"version": "3.12.0",
-					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-					"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
 					"dev": true,
 					"requires": {
 						"argparse": "^1.0.7",
@@ -3886,9 +3801,9 @@
 			}
 		},
 		"homedir-polyfill": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-			"integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+			"integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
 			"dev": true,
 			"requires": {
 				"parse-passwd": "^1.0.0"
@@ -3962,17 +3877,24 @@
 			}
 		},
 		"http-errors": {
-			"version": "1.6.3",
-			"resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.3.tgz",
+			"integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
 			"dev": true,
 			"requires": {
 				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"inherits": "2.0.4",
+				"setprototypeof": "1.1.1",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.0"
 			},
 			"dependencies": {
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				},
 				"statuses": {
 					"version": "1.5.0",
 					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -4003,9 +3925,9 @@
 			}
 		},
 		"iconv-lite": {
-			"version": "0.4.23",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-			"integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
 				"safer-buffer": ">= 2.1.2 < 3"
@@ -4067,9 +3989,9 @@
 			"dev": true
 		},
 		"interpret": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-			"integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
 		},
 		"invert-kv": {
@@ -4201,21 +4123,6 @@
 				}
 			}
 		},
-		"is-dotfile": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
-		},
-		"is-equal-shallow": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
-			"requires": {
-				"is-primitive": "^2.0.0"
-			}
-		},
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -4328,18 +4235,6 @@
 			"requires": {
 				"isobject": "^3.0.1"
 			}
-		},
-		"is-posix-bracket": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
-		},
-		"is-primitive": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
 		},
 		"is-regex": {
 			"version": "1.0.4",
@@ -4514,14 +4409,11 @@
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
 		},
-		"json-stable-stringify": {
+		"json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
-			"requires": {
-				"jsonify": "~0.0.0"
-			}
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+			"dev": true
 		},
 		"json-stringify-safe": {
 			"version": "5.0.1",
@@ -4537,12 +4429,6 @@
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
-		},
-		"jsonify": {
-			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -4632,13 +4518,13 @@
 			}
 		},
 		"liftoff": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.5.0.tgz",
-			"integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
+			"integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
 			"dev": true,
 			"requires": {
 				"extend": "^3.0.0",
-				"findup-sync": "^2.0.0",
+				"findup-sync": "^3.0.0",
 				"fined": "^1.0.1",
 				"flagged-respawn": "^1.0.0",
 				"is-plain-object": "^2.0.4",
@@ -4648,9 +4534,9 @@
 			}
 		},
 		"limiter": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
-			"integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.4.tgz",
+			"integrity": "sha512-XCpr5bElgDI65vVgstP8TWjv6/QKWm9GU5UG0Pr5sLQ3QLo8NVKsioe+Jed5/3vFOe3IQuqE7DKwTvKQkjTHvg==",
 			"dev": true
 		},
 		"load-json-file": {
@@ -4667,25 +4553,31 @@
 			}
 		},
 		"localtunnel": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.1.tgz",
-			"integrity": "sha512-HWrhOslklDvxgOGFLxi6fQVnvpl6XdX4sPscfqMZkzi3gtt9V7LKBWYvNUcpHSVvjwCQ6xzXacVvICNbNcyPnQ==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.2.tgz",
+			"integrity": "sha512-NEKF7bDJE9U3xzJu3kbayF0WTvng6Pww7tzqNb/XtEARYwqw7CKEX7BvOMg98FtE9es2CRizl61gkV3hS8dqYg==",
 			"dev": true,
 			"requires": {
-				"axios": "0.17.1",
-				"debug": "2.6.9",
+				"axios": "0.19.0",
+				"debug": "4.1.1",
 				"openurl": "1.1.1",
 				"yargs": "6.6.0"
 			},
 			"dependencies": {
 				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
+						"ms": "^2.1.1"
 					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"yargs": {
 					"version": "6.6.0",
@@ -4711,9 +4603,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.11",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-			"integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
 			"dev": true
 		},
 		"lodash._basecopy": {
@@ -4782,12 +4674,6 @@
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
 		},
-		"lodash.debounce": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-			"dev": true
-		},
 		"lodash.escape": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
@@ -4839,15 +4725,15 @@
 			"dev": true
 		},
 		"lodash.merge": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-			"integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true
 		},
 		"lodash.mergewith": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-			"integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
 			"dev": true
 		},
 		"lodash.restparam": {
@@ -4961,6 +4847,27 @@
 				"stack-trace": "0.0.10"
 			},
 			"dependencies": {
+				"findup-sync": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
+					"integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
+					"dev": true,
+					"requires": {
+						"detect-file": "^1.0.0",
+						"is-glob": "^3.1.0",
+						"micromatch": "^3.0.4",
+						"resolve-dir": "^1.0.1"
+					}
+				},
+				"is-glob": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.0"
+					}
+				},
 				"micromatch": {
 					"version": "3.1.10",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -4988,12 +4895,6 @@
 			"version": "1.2.17",
 			"resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
 			"integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
-			"dev": true
-		},
-		"math-random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-			"integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
 			"dev": true
 		},
 		"mdn-data": {
@@ -5029,94 +4930,24 @@
 			}
 		},
 		"micromatch": {
-			"version": "2.3.11",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+			"version": "3.1.10",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
-			},
-			"dependencies": {
-				"arr-diff": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-					"dev": true,
-					"requires": {
-						"arr-flatten": "^1.0.1"
-					}
-				},
-				"array-unique": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-					"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-					"dev": true
-				},
-				"braces": {
-					"version": "1.8.5",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-					"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-					"dev": true,
-					"requires": {
-						"expand-range": "^1.8.1",
-						"preserve": "^0.2.0",
-						"repeat-element": "^1.1.2"
-					}
-				},
-				"expand-brackets": {
-					"version": "0.1.5",
-					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-					"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-					"dev": true,
-					"requires": {
-						"is-posix-bracket": "^0.1.0"
-					}
-				},
-				"extglob": {
-					"version": "0.3.2",
-					"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-					"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				},
-				"kind-of": {
-					"version": "3.2.2",
-					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true,
-					"requires": {
-						"is-buffer": "^1.1.5"
-					}
-				}
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"braces": "^2.3.1",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"extglob": "^2.0.4",
+				"fragment-cache": "^0.2.1",
+				"kind-of": "^6.0.2",
+				"nanomatch": "^1.2.9",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.2"
 			}
 		},
 		"mime": {
@@ -5162,9 +4993,9 @@
 			"dev": true
 		},
 		"mixin-deep": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
 			"dev": true,
 			"requires": {
 				"for-in": "^1.0.2",
@@ -5238,9 +5069,9 @@
 			}
 		},
 		"negotiator": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-			"integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+			"integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
 			"dev": true
 		},
 		"next-tick": {
@@ -5362,9 +5193,9 @@
 			}
 		},
 		"now-and-later": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
-			"integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.1.tgz",
+			"integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
 			"dev": true,
 			"requires": {
 				"once": "^1.3.2"
@@ -5537,16 +5368,6 @@
 						"for-in": "^1.0.1"
 					}
 				}
-			}
-		},
-		"object.omit": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
-			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
 			}
 		},
 		"object.pick": {
@@ -5728,35 +5549,6 @@
 				"path-root": "^0.1.1"
 			}
 		},
-		"parse-glob": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
-			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
-			},
-			"dependencies": {
-				"is-extglob": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-					"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-					"dev": true
-				},
-				"is-glob": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-					"dev": true,
-					"requires": {
-						"is-extglob": "^1.0.0"
-					}
-				}
-			}
-		},
 		"parse-json": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -5791,9 +5583,9 @@
 			}
 		},
 		"parseurl": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-			"integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
 			"dev": true
 		},
 		"pascalcase": {
@@ -7058,12 +6850,6 @@
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
 		},
-		"preserve": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
-		},
 		"pretty-hrtime": {
 			"version": "1.0.3",
 			"resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -7144,40 +6930,21 @@
 				"strict-uri-encode": "^1.0.0"
 			}
 		},
-		"randomatic": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-			"dev": true,
-			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
-			},
-			"dependencies": {
-				"is-number": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-					"integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-					"dev": true
-				}
-			}
-		},
 		"range-parser": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-			"integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
 			"dev": true
 		},
 		"raw-body": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-			"integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.1.tgz",
+			"integrity": "sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==",
 			"dev": true,
 			"requires": {
-				"bytes": "3.0.0",
-				"http-errors": "1.6.3",
-				"iconv-lite": "0.4.23",
+				"bytes": "3.1.0",
+				"http-errors": "1.7.3",
+				"iconv-lite": "0.4.24",
 				"unpipe": "1.0.0"
 			}
 		},
@@ -7255,29 +7022,6 @@
 				"graceful-fs": "^4.1.11",
 				"micromatch": "^3.1.10",
 				"readable-stream": "^2.0.2"
-			},
-			"dependencies": {
-				"micromatch": {
-					"version": "3.1.10",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-					"dev": true,
-					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
-					}
-				}
 			}
 		},
 		"rechoir": {
@@ -7333,15 +7077,6 @@
 					"integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
 					"dev": true
 				}
-			}
-		},
-		"regex-cache": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-			"dev": true,
-			"requires": {
-				"is-equal-shallow": "^0.1.3"
 			}
 		},
 		"regex-not": {
@@ -7484,12 +7219,12 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-			"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+			"integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
 			"dev": true,
 			"requires": {
-				"path-parse": "^1.0.5"
+				"path-parse": "^1.0.6"
 			}
 		},
 		"resolve-dir": {
@@ -7705,6 +7440,24 @@
 						"ms": "2.0.0"
 					}
 				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"dev": true,
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+					"dev": true
+				},
 				"statuses": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -7736,6 +7489,30 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
+				},
+				"http-errors": {
+					"version": "1.6.3",
+					"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+					"integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+					"dev": true,
+					"requires": {
+						"depd": "~1.1.2",
+						"inherits": "2.0.3",
+						"setprototypeof": "1.1.0",
+						"statuses": ">= 1.4.0 < 2"
+					}
+				},
+				"setprototypeof": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+					"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+					"dev": true
+				},
+				"statuses": {
+					"version": "1.5.0",
+					"resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+					"integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+					"dev": true
 				}
 			}
 		},
@@ -7764,9 +7541,9 @@
 			"dev": true
 		},
 		"set-value": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^2.0.1",
@@ -7787,9 +7564,9 @@
 			}
 		},
 		"setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+			"integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
 			"dev": true
 		},
 		"shelljs": {
@@ -8356,13 +8133,13 @@
 			"dev": true
 		},
 		"tar": {
-			"version": "2.2.1",
-			"resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+			"integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
 			"dev": true,
 			"requires": {
 				"block-stream": "*",
-				"fstream": "^1.0.2",
+				"fstream": "^1.0.12",
 				"inherits": "2"
 			}
 		},
@@ -8431,9 +8208,9 @@
 			}
 		},
 		"through2-filter": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-2.0.0.tgz",
-			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-3.0.0.tgz",
+			"integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
 			"dev": true,
 			"requires": {
 				"through2": "~2.0.0",
@@ -8513,6 +8290,12 @@
 				"through2": "^2.0.3"
 			}
 		},
+		"toidentifier": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+			"integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+			"dev": true
+		},
 		"tough-cookie": {
 			"version": "2.4.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -8561,6 +8344,12 @@
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
 			"dev": true
 		},
+		"type": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
+			"integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg==",
+			"dev": true
+		},
 		"typedarray": {
 			"version": "0.0.6",
 			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -8586,9 +8375,9 @@
 			"dev": true
 		},
 		"undertaker": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.0.tgz",
-			"integrity": "sha1-M52kZGJS0ILcN45wgGcpl1DhG0k=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/undertaker/-/undertaker-1.2.1.tgz",
+			"integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
 			"dev": true,
 			"requires": {
 				"arr-flatten": "^1.0.1",
@@ -8615,38 +8404,15 @@
 			"dev": true
 		},
 		"union-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
 			"dev": true,
 			"requires": {
 				"arr-union": "^3.1.0",
 				"get-value": "^2.0.6",
 				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
-			},
-			"dependencies": {
-				"extend-shallow": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-					"dev": true,
-					"requires": {
-						"is-extendable": "^0.1.0"
-					}
-				},
-				"set-value": {
-					"version": "0.4.3",
-					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-					"dev": true,
-					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
-					}
-				}
+				"set-value": "^2.0.1"
 			}
 		},
 		"uniq": {
@@ -8662,13 +8428,13 @@
 			"dev": true
 		},
 		"unique-stream": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.2.1.tgz",
-			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.3.1.tgz",
+			"integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
 			"dev": true,
 			"requires": {
-				"json-stable-stringify": "^1.0.0",
-				"through2-filter": "^2.0.0"
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"through2-filter": "^3.0.0"
 			}
 		},
 		"universalify": {
@@ -8736,9 +8502,9 @@
 			}
 		},
 		"upath": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-			"integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+			"integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
 			"dev": true
 		},
 		"uri-js": {
@@ -8791,9 +8557,9 @@
 			"dev": true
 		},
 		"v8flags": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
-			"integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+			"integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
 			"dev": true,
 			"requires": {
 				"homedir-polyfill": "^1.0.1"
@@ -8985,9 +8751,9 @@
 			"dev": true
 		},
 		"ws": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.2.tgz",
-			"integrity": "sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==",
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
+			"integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
 			"dev": true,
 			"requires": {
 				"async-limiter": "~1.0.0"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
 		"gulp-cssnano": "2.1.3",
 		"gulp-autoprefixer": "6.0.0",
 		"gulp-svgmin": "2.1.0",
-		"browser-sync": "2.26.3"
+		"browser-sync": "2.26.7"
 	}
 }


### PR DESCRIPTION
Fixed all but two security vulnerabilities via npm audit fix. This should resolve issue #80.
The remaining two vulnerabilities are with gulp-cssnano reported on issue #78.