### PR TITLE
Fix for current node-sass 404 error

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Some information is automatically pulled in from it and added to a header that's
 }
 ```
 
-*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things.*
+*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things. If any of the other fields are removed, make sure to remove reference to them in the Header (under `var banner` in `gulpfile.js`) or `gulp watch` won't run.*
 
 ### JavaScript
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ var paths = {
 	},
 	svgs: {
 		input: 'src/svg/*.svg',
-		output: 'dist/images/'
+		output: 'dist/svg/'
 	},
 	copy: {
 		input: 'src/copy/**/*',

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"> 0.25%"
 	],
 	"devDependencies": {
+		"node-sass": "4.13.0",
 		"gulp": "4.0.2",
 		"del": "3.0.0",
 		"lazypipe": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"url": "http://link-to-your-git-repo.com"
 	},
 	"boilerplate": {
-		"version": "2.2.5",
+		"version": "2.2.6",
 		"author": "Chris Ferdinandi",
 		"url": "https://gomakethings.com",
 		"repo": "http://github.com/cferdinandi/gulp-boilerplate"


### PR DESCRIPTION
Added node-sass to devDependecies. This normally installs as a sub-dependency of one of the packages already listed in devDependencies but currently users get a 404 error when running npm install without it.

Also added a warning about a conflict arrising from altering the package.json fields without altering the relevant sections of the Header also.