### PR TITLE
Add the removal of unused CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Some information is automatically pulled in from it and added to a header that's
 }
 ```
 
-*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things. If any of the other lines are removed, make sure to remove reference to them under "var banner" in gulpfile.js or gulp watch won't run.*
+*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things. If any of the other fields are removed, make sure to remove reference to them under "var banner" in gulpfile.js or gulp watch won't run.*
 
 ### JavaScript
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A boilerplate for building web projects with [Gulp](https://gulpjs.com/). Uses G
 - Optimize SVGs.
 - Copy static files and folders into your `dist` directory.
 - Automatically add headers and project details to JS and CSS files.
+- Remove unused CSS.
 - Create polyfilled and non-polyfilled versions of JS files.
 - Watch for file changes, and automatically recompile build and reload webpages.
 
@@ -89,6 +90,14 @@ Put your [Sass](https://sass-lang.com/) files in the `src/sass` directory.
 
 Gulp generates minified and unminified CSS files. It also includes [autoprefixer](https://github.com/postcss/autoprefixer), which adds vendor prefixes for you.
 
+### Purge Unused CSS
+
+Unused CSS can be removed from your CSS files. To enable this feature, set `purge: true` in `gulpfile.js` (default is `false`). Be sure to go to "Paths to files for PurgeCSS" under paths and list any file that uses or affects your CSS.
+
+By default, all .html files from the copy-output folder and all .js files in the scripts-output folder are set to be analysed. You should add any file which uses or influences your CSS. For example, if you have a page which uses style `.foo` on a nav bar and you have a javascript file which changes the nav bar's class to also include `.bar` once the user scrolls down the page, including the javascript file in the list will allow purgecss to analyse it so it can see that this class is used at some point and so won't be incorrectly considered as unused CSS and removed.
+
+It can take a little trial and error to ensure a page has all of the CSS it's meant to have. Often, whitelisting CSS that you want to be included in all circumstances can fix any issues that arise. Adding `/* purgecss start ignore */` before and `/* purgecss end ignore */` after any CSS in your sass files you want kept no matter what is one method of doing this. For more details on this and other methods, please refer to the [PurgeCSS dcoumentation](https://www.purgecss.com/whitelisting).
+
 ### SVGs
 
 Place SVG files in the `src/svg` directory.
@@ -126,7 +135,8 @@ var settings = {
 	styles: true,
 	svgs: true,
 	copy: true,
-	reload: true
+	reload: true,
+	purge: false
 };
 ```
 
@@ -162,6 +172,23 @@ var paths = {
 	},
 	reload: './dist/'
 };
+```
+
+If purging of unused CSS is enabled, set the paths to any file that uses or influences your CSS. By default, it is set to analyse all html files in the copy - output path and all javascipt files in the scripts - output path. It is safe to remove or alter these lines if they are not relevant to your project.
+
+```js
+/**
+ * Paths to files for PurgeCSS
+ */
+var purgePipe = lazypipe()
+	.pipe(purgecss, {
+		content: [
+			// Add files below that use or affect your CSS. These are analysed by PurgeCSS to see what CSS is or isn't used.
+			// E.g. paths.scripts.output + '/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js'
+			paths.copy.output + '**/*.html',
+			paths.scripts.output + '**/*.js',
+		]
+	});
 ```
 
 ### Header

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Gulp generates minified and unminified CSS files. It also includes [autoprefixer
 
 Place SVG files in the `src/svg` directory.
 
-SVG files will be optimized with [SVGO](https://github.com/svg/svgo) and compiled into `dist/images`.
+SVG files will be optimized with [SVGO](https://github.com/svg/svgo) and compiled into `dist/svg`.
 
 ### Copy Files
 
@@ -154,7 +154,7 @@ var paths = {
 	},
 	svgs: {
 		input: 'src/svg/*.svg',
-		output: 'dist/images/'
+		output: 'dist/svg/'
 	},
 	copy: {
 		input: 'src/copy/*',

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Some information is automatically pulled in from it and added to a header that's
 }
 ```
 
-*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things. If any of the other fields are removed, make sure to remove reference to them under "var banner" in gulpfile.js or gulp watch won't run.*
+*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things. If any of the other fields are removed, make sure to remove reference to them under `var banner` in `gulpfile.js` or `gulp watch` won't run.*
 
 ### JavaScript
 

--- a/README.md
+++ b/README.md
@@ -133,10 +133,10 @@ var settings = {
 	scripts: true,
 	polyfills: true,
 	styles: true,
+	purge: false,
 	svgs: true,
 	copy: true,
-	reload: true,
-	purge: false
+	reload: true
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ var paths = {
 	},
 	svgs: {
 		input: 'src/svg/*.svg',
-		output: 'dist/svg/'
+		output: 'dist/images/'
 	},
 	copy: {
 		input: 'src/copy/*',

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Some information is automatically pulled in from it and added to a header that's
 }
 ```
 
-*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things. If any of the other fields are removed, make sure to remove reference to them under `var banner` in `gulpfile.js` or `gulp watch` won't run.*
+*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things. If any of the other fields are removed, make sure to remove reference to them in the Header (under `var banner` in `gulpfile.js`) or `gulp watch` won't run.*
 
 ### JavaScript
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Some information is automatically pulled in from it and added to a header that's
 }
 ```
 
-*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things.*
+*__Note:__ `devDependencies` are the dependencies Gulp uses. Don't change these or you'll break things. If any of the other lines are removed, make sure to remove reference to them under "var banner" in gulpfile.js or gulp watch won't run.*
 
 ### JavaScript
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Gulp generates minified and unminified CSS files. It also includes [autoprefixer
 
 Place SVG files in the `src/svg` directory.
 
-SVG files will be optimized with [SVGO](https://github.com/svg/svgo) and compiled into `dist/svg`.
+SVG files will be optimized with [SVGO](https://github.com/svg/svgo) and compiled into `dist/images`.
 
 ### Copy Files
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ var purgePipe = lazypipe()
 	.pipe(purgecss, {
 		content: [
 			// Add files below that use or affect your CSS. These are analysed by PurgeCSS to see what CSS is or isn't used.
-			// E.g. paths.scripts.output + '/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js'
+			// E.g. paths.copy.output + 'node_modules/bootstrap/dist/js/bootstrap.bundle.min.js'
 			paths.copy.output + '**/*.html',
 			paths.scripts.output + '**/*.js',
 		]

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,10 +46,10 @@ var settings = {
 	scripts: true,
 	polyfills: true,
 	styles: true,
+	purge: false,
 	svgs: true,
 	copy: true,
-	reload: true,
-	purge: false
+	reload: true
 };
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -87,7 +87,7 @@ var purgePipe = lazypipe()
 	.pipe(purgecss, {
 		content: [
 			// Add files below that use or affect your CSS. These are analysed by PurgeCSS to see what CSS is or isn't used.
-			// E.g. paths.copy.output + 'dist/node_modules/bootstrap/dist/js/bootstrap.bundle.min.js'
+			// E.g. paths.copy.output + 'node_modules/bootstrap/dist/js/bootstrap.bundle.min.js'
 			paths.copy.output + '**/*.html',
 			paths.scripts.output + '**/*.js',
 		]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"url": "http://link-to-your-git-repo.com"
 	},
 	"boilerplate": {
-		"version": "2.2.6",
+		"version": "2.2.7",
 		"author": "Chris Ferdinandi",
 		"url": "https://gomakethings.com",
 		"repo": "http://github.com/cferdinandi/gulp-boilerplate"
@@ -41,6 +41,7 @@
 		"cssnano": "4.1.10",
 		"autoprefixer": "9.6.1",
 		"gulp-svgmin": "2.1.0",
-		"browser-sync": "2.26.7"
+		"browser-sync": "2.26.7",
+		"gulp-purgecss": "1.2.0",
 	}
 }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,6 @@
 		"gulp-svgmin": "2.1.0",
 		"browser-sync": "2.26.7",
 		"gulp-purgecss": "1.2.0",
+		"gulp-if": "3.0.0"
 	}
 }


### PR DESCRIPTION
PurgeCSS is used to analyse any CSS which is unused. This is then removed from the CSS files, helping to optimise page load speeds.

Purging of unused CSS is currently set to false by default. Since this process potentially requires a little more input from the user than existing functions, it seemed sensible to have this as an optional function that can be enabled if desired.

Moved "Gulp Packages" to top of gulpfile.js as this needs to run before lazypipes can be used. A lazypipe is used in the paths section now for user clarity in adding their own purgecss related paths.  I've been unsuccesul in calling a path directly into the 'content' part of purgecss using any other method so far, so adding the whole process as a lazypipe under the current paths seemed the best alternative for now. Perhaps you can think of a way besides this that works that I couldn't think of.

There is a bug with gulp watch and lazypipe which causes active watching to fail if a lazypipe is the last pipe used in a series of pipes. To get around this, I've added ".pipe(gutil.noop());" after the relevant lazypipes. This does nothing but by simply being there, this is a workaround for the bug.

As purgecss can read comments in a CSS file that indicate whitelisted CSS that should not be removed under any circumstances, 'sourceComments' in the sass pipe has been set to false. We then delay the minifying of CSS until after purgecss has run IF purgecss is set to run so that it doesn't needlessly run twice. As such, CSS minification was added to a new lazypipe to be called when needed.

Purging of CSS needs to read the outputted CSS, not the original sass file, to work correctly. Therefore it is set to run as a non-asynchronous task after all other tasks have run.

----

In keeping with the ease of use this boilerplate offers, this method of using PurgeCSS is done in a simplified way. Any CSS which is used on any page will not be excluded from any of the CSS files. This should still offer file size reductions and page load speed improvements so it's worth doing but ideally a CSS file which is only used on a.html and b.html should only exclude CSS unused on just those pages. The setup I've used means CSS found on c.html will also be kept in the CSS files that only a.html and b.html use.

Without being able to specify the name of the CSS file and then listing any content which uses it, this is the best way to go about it. This is possible to do but right now I can't think of a way of adding this without making the use of this boilerplate overly complex and so the more more broad method I've used is a good alternative that still makes excellent potential file size and speed savings for the user, particularly if they used a framework such as Bootstrap which will have a LOT of unused CSS for most people.