### PR TITLE
Convert links protocol to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ A boilerplate for building web projects with [Gulp](https://gulpjs.com/). Uses G
 
 Make sure these are installed first.
 
-- [Node.js](http://nodejs.org)
-- [Gulp Command Line Utility](http://gulpjs.com) `npm install --global gulp-cli`
+- [Node.js](https://nodejs.org)
+- [Gulp Command Line Utility](https://gulpjs.com) `npm install --global gulp-cli`
 
 ### Quick Start
 
@@ -62,12 +62,12 @@ Some information is automatically pulled in from it and added to a header that's
 	"main": "./dist/your-main-js-file.js",
 	"author": {
 		"name": "YOUR NAME",
-		"url": "http://link-to-your-website.com"
+		"url": "https://link-to-your-website.com"
 	},
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "http://link-to-your-git-repo.com"
+		"url": "https://link-to-your-git-repo.com"
 	},
 	"devDependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -5,18 +5,18 @@
 	"main": "./dist/your-main-js-file.js",
 	"author": {
 		"name": "YOUR NAME",
-		"url": "http://link-to-your-website.com"
+		"url": "https://link-to-your-website.com"
 	},
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "http://link-to-your-git-repo.com"
+		"url": "https://link-to-your-git-repo.com"
 	},
 	"boilerplate": {
 		"version": "2.2.6",
 		"author": "Chris Ferdinandi",
 		"url": "https://gomakethings.com",
-		"repo": "http://github.com/cferdinandi/gulp-boilerplate"
+		"repo": "https://github.com/cferdinandi/gulp-boilerplate"
 	},
 	"browserslist": [
 		"last 2 versions",


### PR DESCRIPTION
Converts all `http://` references to `https://` in documentation and `package.json` to promote usage of `https://` protocol.